### PR TITLE
include patches in allowed versions

### DIFF
--- a/thor-hollaback.gemspec
+++ b/thor-hollaback.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'hollaback', '~> 0.1.0'
-  spec.add_dependency 'thor', '~> 0.20', '>= 0.19'
+  spec.add_dependency 'thor', '~> 0.20', '>= 0.19.1'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'minitest', '~> 5.10'


### PR DESCRIPTION
I was trying to install autodeploy and this happened:

          ip-10-4-0-115:nginx-container rluckom$ gem install autodeploy            
          ERROR:  While executing gem ... (Gem::DependencyError)  Unable to resolve dependencies: autodeploy requires thor (~> 0.19.1); thor-hollaback requires thor (>= 0.19, ~> 0.20); defcon requires thor (~> 0.19.1)

I looked into the inconsistency, and it appears that this commit (https://github.com/localytics/thor-hollaback/commit/79a94d90d3f81db3cc352a7372c1fe55db17bf36) from 5 days ago changed the required `thor` version from ` '~> 0.19', '>= 0.19.1'` to `'~> 0.20', '>= 0.19'`. I _think_ that by omitting any patch version, this new range excludes patch versions _between_ `0.19` and `0.20`, while allowing minor versions `>= 19`. I think this change allows those minor versions.